### PR TITLE
feature/dashParryEnemyHitKnockback

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -52,7 +52,7 @@ dash={
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":1.0,"script":null)
 ]
 }
-parry={
+block={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":75,"key_label":0,"unicode":107,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":10,"pressure":0.0,"pressed":false,"script":null)

--- a/scenes/actors/enemies/BlockEnemy.tscn
+++ b/scenes/actors/enemies/BlockEnemy.tscn
@@ -1,13 +1,15 @@
-[gd_scene load_steps=4 format=3 uid="uid://c8dx52enlmf"]
+[gd_scene load_steps=5 format=3 uid="uid://c8dx52enlmf"]
 
 [ext_resource type="Script" uid="uid://b16jufadlxgfl" path="res://scenes/actors/enemies/block_enemy.gd" id="1_gw6gb"]
 [ext_resource type="Texture2D" uid="uid://dea12axubg6ne" path="res://assets/sprites/dugtrio.png" id="1_u7xqj"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_uf5xb"]
-size = Vector2(110, 114.5)
+size = Vector2(92, 98.5)
 
-[node name="BlockEnemy" type="Area2D"]
-position = Vector2(500, -100)
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_gw6gb"]
+size = Vector2(122, 116)
+
+[node name="BlockEnemy" type="CharacterBody2D" groups=["enemy"]]
 script = ExtResource("1_gw6gb")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -17,3 +19,8 @@ shape = SubResource("RectangleShape2D_uf5xb")
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(-3, -64)
 texture = ExtResource("1_u7xqj")
+
+[node name="DamageArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DamageArea"]
+shape = SubResource("RectangleShape2D_gw6gb")

--- a/scenes/actors/enemies/block_enemy.gd
+++ b/scenes/actors/enemies/block_enemy.gd
@@ -1,10 +1,48 @@
-# BlockEnemy.gd
-extends Area2D
-@export var damage := 1
+extends CharacterBody2D
+
+@export var max_hp: int = 3
+@export var touch_damage: int = 1
+@export var gravity: float = 1300.0
+@export var kb_force: float = 220.0
+@export var kb_up: float = 120.0
+
+# ↓ NUEVO: fricción en suelo y aire, y duración del golpe
+@export var ground_friction: float = 2000.0
+@export var air_drag: float = 200.0
+@export var hurt_time: float = 0.15
+
+var hp: int
+var _hurt_timer: float = 0.0
 
 func _ready() -> void:
-	body_entered.connect(_on_body_entered)
+	hp = max_hp
+	add_to_group("enemy")
+	$DamageArea.body_entered.connect(_on_damage_area_body_entered)
 
-func _on_body_entered(body: Node) -> void:
+func _physics_process(delta: float) -> void:
+	if not is_on_floor():
+		velocity.y += gravity * delta
+
+	# ↓ NUEVO: desaceleración horizontal para que no se deslice infinito
+	var decel := ground_friction if is_on_floor() else air_drag
+	velocity.x = move_toward(velocity.x, 0.0, decel * delta)
+
+	_hurt_timer = maxf(_hurt_timer - delta, 0.0)  # (opcional, por si después usás “stun”)
+	move_and_slide()
+
+func _on_damage_area_body_entered(body: Node) -> void:
 	if body.is_in_group("player") and body.has_method("take_damage"):
-		body.take_damage(damage, global_position)
+		body.take_damage(touch_damage, global_position)
+
+# Llamado por el Player al golpear
+func take_damage(amount: int, from_pos: Vector2) -> void:
+	hp = max(hp - amount, 0)
+	_hurt_timer = hurt_time
+
+	# Knockback con “saltito”
+	var dir: float = 1.0 if global_position.x >= from_pos.x else -1.0
+	velocity.x = dir * kb_force
+	velocity.y = -kb_up
+
+	if hp == 0:
+		queue_free()

--- a/scenes/actors/player/Player.gd
+++ b/scenes/actors/player/Player.gd
@@ -1,11 +1,13 @@
 extends CharacterBody2D
 
-signal health_changed(current: int, max: int)
+signal health_changed(current: float, max: int)
 
 @export var max_hp: int = 5
 @export var invuln_time: float = 0.6
-var hp: int = 0
+var hp: float = 0.0
 var _invuln_timer: float = 0.0
+
+var _facing: int = 1  # 1 = derecha, -1 = izquierda
 
 # Knockback / stun
 @export var knockback_force: float = 320.0
@@ -13,7 +15,7 @@ var _invuln_timer: float = 0.0
 @export var hurt_stun_time: float = 0.18
 var _stun_timer: float = 0.0
 
-# ===== Tunables =====
+# ===== Movement tunables =====
 @export var speed: float = 200.0
 @export var jump_force: float = 420.0
 @export var gravity: float = 1300.0
@@ -21,6 +23,39 @@ var _stun_timer: float = 0.0
 @export var jump_buffer: float = 0.12
 @export var cut_jump_factor: float = 0.5
 @export var max_air_jumps: int = 1
+
+# ===== Block / Parry =====
+@export var parry_window: float = 0.12
+@export var block_movespeed_factor: float = 0.35
+@export var block_kb_scale: float = 0.3
+var _is_blocking: bool = false
+var _parry_timer: float = 0.0
+
+# ===== Dash (hold-to-extend) =====
+@export var dash_speed: float = 480.0
+@export var dash_min_time: float = 0.06
+@export var dash_max_time: float = 0.20
+@export var dash_cooldown: float = 0.25
+var _is_dashing: bool = false
+var _dash_timer: float = 0.0
+var _dash_cd: float = 0.0
+var _dash_dir: float = 1.0
+
+# ===== Attack (config) =====
+@export var attack_damage: int = 1
+@export var attack_windup: float = 0.06   # preparación
+@export var attack_active: float = 0.08   # ventana que pega
+@export var attack_recovery: float = 0.12 # salida
+@export var attack_offset_x: float = 16.0 # distancia de la hitbox frente al player
+
+# ===== Attack (estado) =====
+enum AttackState { IDLE, WINDUP, ACTIVE, RECOVERY }
+var _attack_state: AttackState = AttackState.IDLE
+var _attack_timer: float = 0.0
+var _already_hit := {}  # evita golpear dos veces el mismo body por swing
+
+@onready var _attack_pivot: Node2D = $AttackPivot
+@onready var _hitbox: Area2D = $AttackPivot/Hitbox
 
 # ===== Internos =====
 var _coyote_timer: float = 0.0
@@ -32,10 +67,12 @@ func _ready() -> void:
 	if has_node("Camera2D"):
 		$Camera2D.make_current()
 	_reset_air_jumps()
-	hp = max_hp   # (no emitimos aquí; Main inicializa el HUD una vez)
+	hp = float(max_hp)  # HUD se inicializa desde Main
+	if is_instance_valid(_hitbox):
+		_hitbox.monitoring = false
 
 func _physics_process(delta: float) -> void:
-	# --- Timers ---
+	# --- Timers base ---
 	var on_floor_now := is_on_floor()
 	if on_floor_now:
 		_coyote_timer = coyote_time
@@ -46,11 +83,53 @@ func _physics_process(delta: float) -> void:
 	if Input.is_action_just_pressed("jump"):
 		_buffer_timer = jump_buffer
 
-	# tick de invulnerabilidad + stun
 	_invuln_timer = max(_invuln_timer - delta, 0.0)
 	_stun_timer = max(_stun_timer - delta, 0.0)
 
-	# --- Gravedad ---
+	# --- Block / Parry input ---
+	if Input.is_action_just_pressed("block"):
+		_is_blocking = true
+		_parry_timer = parry_window
+	elif Input.is_action_just_released("block"):
+		_is_blocking = false
+	_parry_timer = max(_parry_timer - delta, 0.0)
+
+	# --- Posicionar hitbox frente al player (si existe) ---
+	if is_instance_valid(_attack_pivot):
+		_attack_pivot.position.x = attack_offset_x * float(_facing)
+
+	# --- Dash control ---
+	_dash_cd = max(_dash_cd - delta, 0.0)
+	if not _is_dashing and _stun_timer <= 0.0 and not _is_blocking and Input.is_action_just_pressed("dash") and _dash_cd <= 0.0:
+		var x_in := Input.get_axis("move_left", "move_right")
+		if x_in == 0.0:
+			_dash_dir = float(_facing)   # usa última dirección conocida
+		else:
+			_dash_dir = 1.0 if x_in > 0.0 else -1.0
+			_facing = int(_dash_dir)     # opcional: actualizar facing
+		_is_dashing = true
+		_dash_timer = 0.0
+
+	if _is_dashing:
+		_dash_timer += delta
+		velocity.y = 0.0
+		velocity.x = _dash_dir * dash_speed
+
+		var stop_early := not Input.is_action_pressed("dash") and _dash_timer >= dash_min_time
+		var stop_max := _dash_timer >= dash_max_time
+		if stop_early or stop_max:
+			_is_dashing = false
+			_dash_cd = dash_cooldown
+
+		move_and_slide()
+		_was_on_floor = on_floor_now
+		return
+
+	# --- Input de ataque (no atacar si stuneado/dashing/bloqueando) ---
+	if _attack_state == AttackState.IDLE and _stun_timer <= 0.0 and not _is_dashing and not _is_blocking and Input.is_action_just_pressed("attack"):
+		_start_attack()
+
+	# --- Gravedad (si no dashing) ---
 	if not on_floor_now:
 		velocity.y += gravity * delta
 
@@ -72,12 +151,17 @@ func _physics_process(delta: float) -> void:
 
 	# --- Movimiento horizontal ---
 	if _stun_timer > 0.0:
-		# Mantener el knockback y frenarlo suavemente (no pisar velocity.x)
-		var decel := 800.0  # probá 600–1200
+		var decel := 800.0
 		velocity.x = move_toward(velocity.x, 0.0, decel * delta)
 	else:
 		var x := Input.get_axis("move_left", "move_right")
-		velocity.x = x * speed
+		if x != 0.0:
+			_facing = 1 if x > 0.0 else -1
+		var speed_mul := (block_movespeed_factor if _is_blocking else 1.0)
+		velocity.x = x * speed * speed_mul
+
+	# --- Timeline del ataque ---
+	_update_attack(delta)
 
 	move_and_slide()
 
@@ -92,23 +176,97 @@ func _reset_air_jumps() -> void:
 	else:
 		_air_jumps_left = 0
 
+# ===== Ataque =====
+func _start_attack() -> void:
+	_attack_state = AttackState.WINDUP
+	_attack_timer = attack_windup
+	if is_instance_valid(_hitbox):
+		_hitbox.set_deferred("monitoring", false)
+	_already_hit.clear()
+
+func _update_attack(delta: float) -> void:
+	if _attack_state == AttackState.IDLE:
+		return
+
+	_attack_timer -= delta
+
+	match _attack_state:
+		AttackState.WINDUP:
+			if _attack_timer <= 0.0:
+				_attack_state = AttackState.ACTIVE
+				_attack_timer = attack_active
+				if is_instance_valid(_hitbox):
+					_hitbox.set_deferred("monitoring", true)
+				_already_hit.clear()
+
+		AttackState.ACTIVE:
+			if _attack_timer <= 0.0:
+				_attack_state = AttackState.RECOVERY
+				_attack_timer = attack_recovery
+				if is_instance_valid(_hitbox):
+					_hitbox.set_deferred("monitoring", false)
+
+		AttackState.RECOVERY:
+			if _attack_timer <= 0.0:
+				_attack_state = AttackState.IDLE
+				if is_instance_valid(_hitbox):
+					_hitbox.set_deferred("monitoring", false)
+
+# Señal: Hitbox.body_entered
+func _on_hitbox_body_entered(body: Node2D) -> void:
+	# Solo durante ACTIVE y evitar múltiple hit al mismo cuerpo
+	if _attack_state != AttackState.ACTIVE:
+		return
+	if body in _already_hit:
+		return
+	_already_hit[body] = true
+
+	if body.is_in_group("enemy") and body.has_method("take_damage"):
+		body.take_damage(attack_damage, global_position)
+
 # ===== Daño / Muerte =====
 func take_damage(amount: int, from_pos: Vector2 = global_position) -> void:
+	_is_dashing = false
 	if _invuln_timer > 0.0:
 		return
 
-	hp = max(hp - amount, 0)
+	# Parry
+	if _is_blocking and _parry_timer > 0.0:
+		_invuln_timer = 0.2
+		_stun_timer = 0.0
+		_flash()
+		health_changed.emit(hp, max_hp)
+		return
+
+	# Block
+	if _is_blocking:
+		var dmg: float = amount * 0.5
+		hp = max(hp - dmg, 0.0)
+		_invuln_timer = invuln_time
+		_stun_timer = hurt_stun_time * 0.5
+
+		var dir: float = 1.0 if global_position.x >= from_pos.x else -1.0
+		velocity.x = dir * knockback_force * block_kb_scale
+		velocity.y = -knockback_upward * block_kb_scale
+
+		health_changed.emit(hp, max_hp)
+		_flash()
+		if hp <= 0.0:
+			_die()
+		return
+
+	# Daño normal
+	hp = max(hp - float(amount), 0.0)
 	_invuln_timer = invuln_time
 	_stun_timer = hurt_stun_time
 
-	# Knockback: empuja alejando del origen del golpe
-	var dir: float = 1.0 if global_position.x >= from_pos.x else -1.0
-	velocity.x = dir * knockback_force
+	var dir2: float = 1.0 if global_position.x >= from_pos.x else -1.0
+	velocity.x = dir2 * knockback_force
 	velocity.y = -knockback_upward
 
 	health_changed.emit(hp, max_hp)
 	_flash()
-	if hp == 0:
+	if hp <= 0.0:
 		_die()
 
 func _flash() -> void:
@@ -118,8 +276,6 @@ func _flash() -> void:
 		$Sprite2D.modulate = Color(1, 1, 1)
 
 func _die() -> void:
-	# Respawn simple
 	global_position.y = -100
-	global_position.x = 0
-	hp = max_hp
+	hp = float(max_hp)
 	health_changed.emit(hp, max_hp)

--- a/scenes/actors/player/Player.tscn
+++ b/scenes/actors/player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://x38mfda7ln1p"]
+[gd_scene load_steps=5 format=3 uid="uid://x38mfda7ln1p"]
 
 [ext_resource type="Texture2D" uid="uid://bci7x8uqumf7g" path="res://assets/sprites/151.webp" id="1_iugxn"]
 [ext_resource type="Script" uid="uid://c37tflrxlcuc1" path="res://scenes/actors/player/Player.gd" id="1_u84y5"]
@@ -6,17 +6,28 @@
 [sub_resource type="CircleShape2D" id="CircleShape2D_u84y5"]
 radius = 50.01
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_u84y5"]
+size = Vector2(144, 20)
+
 [node name="Player" type="CharacterBody2D" groups=["player"]]
-position = Vector2(0, -100)
-collision_mask = 2
 script = ExtResource("1_u84y5")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(-28, -4)
+scale = Vector2(0.65, 0.675)
 texture = ExtResource("1_iugxn")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(-6, 14)
 shape = SubResource("CircleShape2D_u84y5")
 
 [node name="Camera2D" type="Camera2D" parent="."]
+
+[node name="AttackPivot" type="Node2D" parent="."]
+
+[node name="Hitbox" type="Area2D" parent="AttackPivot"]
+monitoring = false
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttackPivot/Hitbox"]
+shape = SubResource("RectangleShape2D_u84y5")
+
+[connection signal="body_entered" from="AttackPivot/Hitbox" to="." method="_on_hitbox_body_entered"]

--- a/scenes/main/Main.tscn
+++ b/scenes/main/Main.tscn
@@ -16,7 +16,9 @@ script = ExtResource("1_1rhdn")
 position = Vector2(500, -60)
 
 [node name="BlockEnemy" parent="RoomTest" instance=ExtResource("3_dc040")]
+position = Vector2(-500, -500)
 
 [node name="Player" parent="." instance=ExtResource("2_gyg6b")]
+position = Vector2(0, -250)
 
 [node name="HUD" parent="." instance=ExtResource("6_1rhdn")]

--- a/scenes/world/Room_Test.tscn
+++ b/scenes/world/Room_Test.tscn
@@ -6,8 +6,6 @@ size = Vector2(2000, 50)
 [node name="RoomTest" type="Node2D"]
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
-collision_layer = 2
-collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 shape = SubResource("RectangleShape2D_jiylk")

--- a/ui/hud/hud.gd
+++ b/ui/hud/hud.gd
@@ -1,5 +1,5 @@
 extends CanvasLayer
 @onready var label: Label = $Label
 
-func set_health(current: int, max_hp: int) -> void:
-	label.text = "HP: %d/%d" % [current, max_hp]
+func set_health(current: float, max_hp: int) -> void:
+	label.text = "HP: %.1f/%d" % [current, max_hp]


### PR DESCRIPTION
Dash ahora usa la última dirección (facing) cuando no hay input (evita dashes hacia la derecha al soltar izquierda).

Mantiene dash “hold-to-extend”, parry/block e invuln como estaban.

Enemy (BlockEnemy)

Root: CharacterBody2D con CollisionShape2D habilitado (rectángulo).

Agrego fricción/aceleración inversa: ground_friction y air_drag para que el knockback no deslice infinito.

Agrego _hurt_timer (stun corto) y desaceleración con move_toward en _physics_process.

Knockback “saltito” horizontal/vertical en take_damage.

Conexión de DamageArea.body_entered protegida con is_connected (evita duplicados/errores).

Escenas

Room_Test: unifico Collision Layer/Mask = 1 para piso, player y enemy (colisión consistente).

DamageArea queda sólo para daño por contacto (no bloquea).

Notas

Valores tunables: kb_force, kb_up, ground_friction, air_drag.

Siguiente paso: Hitbox de ataque del player + cooldown.